### PR TITLE
add windows compatibility and refactor openai_api_key and pinecone_api_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [0.7.1](https://github.com/FullStackWithLawrence/aws-openai/compare/v0.7.0...v0.7.1) (2023-12-18)
 
-
 ### Bug Fixes
 
-* refactor and update Layer build resources ([626034c](https://github.com/FullStackWithLawrence/aws-openai/commit/626034c06b7049d5a3638da017da66cddba72244))
+- refactor and update Layer build resources ([626034c](https://github.com/FullStackWithLawrence/aws-openai/commit/626034c06b7049d5a3638da017da66cddba72244))
 
 # [0.7.0](https://github.com/FullStackWithLawrence/aws-openai/compare/v0.6.5...v0.7.0) (2023-12-18)
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@ SHELL := /bin/bash
 S3_BUCKET = openai.lawrencemcdaniel.com
 CLOUDFRONT_DISTRIBUTION_ID = E3AIBM1KMSJOP1
 
+ifeq ($(OS),Windows_NT)
+    PYTHON = python.exe
+    ACTIVATE_VENV = venv\Scripts\activate
+else
+    PYTHON = python3.11
+    ACTIVATE_VENV = source venv/bin/activate
+endif
+PIP = $(PYTHON) -m pip
+
 ifneq ("$(wildcard .env)","")
     include .env
 else
@@ -34,16 +43,16 @@ pre-commit:
 api-init:
 	make api-clean
 	npm install && \
-	python3.11 -m venv venv && \
-	source venv/bin/activate && \
-	pip install --upgrade pip && \
-	pip install -r requirements.txt && \
+	$(PYTHON) -m venv venv && \
+	$(ACTIVATE_VENV) && \
+	$(PIP) install --upgrade pip && \
+	$(PIP) install -r requirements.txt && \
 	deactivate && \
 	cd ./api/terraform/python/layer_genai/ && \
-	python3.11 -m venv venv && \
-	source venv/bin/activate && \
-	pip install --upgrade pip && \
-	pip install -r requirements.txt && \
+	$(PYTHON) -m venv venv && \
+	$(ACTIVATE_VENV) && \
+	$(PIP) install --upgrade pip && \
+	$(PIP) install -r requirements.txt && \
 	deactivate && \
 	pre-commit install
 

--- a/api/terraform/python/openai_api/__version__.py
+++ b/api/terraform/python/openai_api/__version__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # DO NOT EDIT.
 # Managed via automated CI/CD in .github/workflows/semanticVersionBump.yml.
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/api/terraform/python/openai_api/common/conf.py
+++ b/api/terraform/python/openai_api/common/conf.py
@@ -26,7 +26,7 @@ from openai_api.common.exceptions import (
     OpenAIAPIConfigurationError,
     OpenAIAPIValueError,
 )
-from pydantic import Field, ValidationError, validator
+from pydantic import Field, SecretStr, ValidationError, validator
 from pydantic_settings import BaseSettings
 
 
@@ -219,14 +219,14 @@ class Settings(BaseSettings):
     openai_api_organization: Optional[str] = Field(
         SettingsDefaults.OPENAI_API_ORGANIZATION, env="OPENAI_API_ORGANIZATION"
     )
-    openai_api_key: Optional[str] = Field(SettingsDefaults.OPENAI_API_KEY, env="OPENAI_API_KEY")
+    openai_api_key: Optional[SecretStr] = Field(SettingsDefaults.OPENAI_API_KEY, env="OPENAI_API_KEY")
     openai_endpoint_image_n: Optional[int] = Field(
         SettingsDefaults.OPENAI_ENDPOINT_IMAGE_N, env="OPENAI_ENDPOINT_IMAGE_N"
     )
     openai_endpoint_image_size: Optional[str] = Field(
         SettingsDefaults.OPENAI_ENDPOINT_IMAGE_SIZE, env="OPENAI_ENDPOINT_IMAGE_SIZE"
     )
-    pinecone_api_key: Optional[str] = Field(SettingsDefaults.PINECONE_API_KEY, env="PINECONE_API_KEY")
+    pinecone_api_key: Optional[SecretStr] = Field(SettingsDefaults.PINECONE_API_KEY, env="PINECONE_API_KEY")
     shared_resource_identifier: Optional[str] = Field(
         SettingsDefaults.SHARED_RESOURCE_IDENTIFIER, env="SHARED_RESOURCE_IDENTIFIER"
     )

--- a/api/terraform/python/openai_api/common/tests/test_configuration.py
+++ b/api/terraform/python/openai_api/common/tests/test_configuration.py
@@ -65,18 +65,26 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(mock_settings.langchain_memory_key, SettingsDefaults.LANGCHAIN_MEMORY_KEY)
         self.assertEqual(mock_settings.openai_endpoint_image_n, SettingsDefaults.OPENAI_ENDPOINT_IMAGE_N)
         self.assertEqual(mock_settings.openai_endpoint_image_size, SettingsDefaults.OPENAI_ENDPOINT_IMAGE_SIZE)
-        self.assertEqual(mock_settings.openai_api_key, SettingsDefaults.OPENAI_API_KEY)
+        # pylint: disable=no-member
+        openai_api_key = mock_settings.openai_api_key.get_secret_value() if mock_settings.openai_api_key else None
+        self.assertEqual(openai_api_key, SettingsDefaults.OPENAI_API_KEY)
         self.assertEqual(mock_settings.openai_api_organization, SettingsDefaults.OPENAI_API_ORGANIZATION)
-        self.assertEqual(mock_settings.pinecone_api_key, SettingsDefaults.PINECONE_API_KEY)
+        # pylint: disable=no-member
+        pinecone_api_key = mock_settings.pinecone_api_key.get_secret_value() if mock_settings.pinecone_api_key else None
+        self.assertEqual(pinecone_api_key, SettingsDefaults.PINECONE_API_KEY)
 
     def test_conf_defaults_secrets(self):
         """Test that settings == SettingsDefaults when no .env is in use."""
         os.environ.clear()
         mock_settings = Settings()
 
-        self.assertEqual(mock_settings.openai_api_key, None)
+        # pylint: disable=no-member
+        openai_api_key = mock_settings.openai_api_key.get_secret_value() if mock_settings.openai_api_key else None
+        self.assertEqual(openai_api_key, None)
         self.assertEqual(mock_settings.openai_api_organization, None)
-        self.assertEqual(mock_settings.pinecone_api_key, None)
+        # pylint: disable=no-member
+        pinecone_api_key = mock_settings.pinecone_api_key.get_secret_value() if mock_settings.pinecone_api_key else None
+        self.assertEqual(pinecone_api_key, None)
 
     def test_env_nulls(self):
         """Test that settings handles missing .env values."""

--- a/api/terraform/python/openai_api/lambda_langchain/lambda_handler.py
+++ b/api/terraform/python/openai_api/lambda_langchain/lambda_handler.py
@@ -113,7 +113,10 @@ def handler(event, context):
                 # 2. initialize the LangChain ChatOpenAI model
                 # -------------------------------------------------------------
                 llm = ChatOpenAI(
-                    model=model, temperature=temperature, max_tokens=max_tokens, api_key=settings.openai_api_key
+                    model=model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    api_key=settings.openai_api_key.get_secret_value(),
                 )
                 prompt = ChatPromptTemplate(
                     messages=[

--- a/api/terraform/python/openai_api/lambda_openai_v2/lambda_handler.py
+++ b/api/terraform/python/openai_api/lambda_openai_v2/lambda_handler.py
@@ -49,7 +49,7 @@ from openai_api.common.validators import (  # validate_embedding_request,
 
 
 openai.organization = settings.openai_api_organization
-openai.api_key = settings.openai_api_key
+openai.api_key = settings.openai_api_key.get_secret_value()
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ * ] Refactor
- [ * ] Chore

## Resolves

- Fixes windows incompatibility problems with python virtual environment init

## Changes

- refactor openai_api_key and pinecone_api_key to use pydantic SecretStr

_Describe what this Pull Request does_

## Testing

<!-- Describe how the changes can be tested -->

_Describe the testing that has been done or needs to be done_

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

_Add any relevant screenshots_

## Dependencies

<!-- List any dependencies that are required for this change -->

_List dependencies_

## Breaking Changes

<!-- Does this PR contain any breaking changes? -->

_Describe any breaking changes_
